### PR TITLE
OOO-735, 770

### DIFF
--- a/Geist Heist/Assets/Prefabs/Constants/Sub Constants/LevelManager.prefab
+++ b/Geist Heist/Assets/Prefabs/Constants/Sub Constants/LevelManager.prefab
@@ -44,5 +44,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 189a36b9c1ffc2241beae226187f8b8b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::LevelManager
-  destroyGameObject: 0
   SpawnLocation: {x: 0, y: 0, z: 0}
+  fadeToBlack: {fileID: 3539313296203810109, guid: 0149ec701953a784782033d31a875ed7, type: 3}

--- a/Geist Heist/Assets/Prefabs/UI/Level Confirmation/FadeToBlackCanvas.prefab
+++ b/Geist Heist/Assets/Prefabs/UI/Level Confirmation/FadeToBlackCanvas.prefab
@@ -1,0 +1,208 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3539313296203810109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6393458886746589544}
+  - component: {fileID: 437887796530970419}
+  - component: {fileID: 756791955263287671}
+  - component: {fileID: 1538646284141028955}
+  - component: {fileID: 8563458514380257581}
+  - component: {fileID: 6955057048009195138}
+  m_Layer: 5
+  m_Name: FadeToBlackCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6393458886746589544
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3539313296203810109}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6377543437461535579}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &437887796530970419
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3539313296203810109}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 10
+  m_TargetDisplay: 0
+--- !u!114 &756791955263287671
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3539313296203810109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &1538646284141028955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3539313296203810109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!225 &8563458514380257581
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3539313296203810109}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &6955057048009195138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3539313296203810109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 574413415719e3244bab524e7c1cf53a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::FadeToBlack
+  destroyGameObject: 0
+  fadeCanvasGroup: {fileID: 8563458514380257581}
+  secondsForFade: 1
+--- !u!1 &7755504070399221049
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6377543437461535579}
+  - component: {fileID: 1902856891810225187}
+  - component: {fileID: 3619349430151985246}
+  m_Layer: 5
+  m_Name: Black
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6377543437461535579
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7755504070399221049}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6393458886746589544}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1902856891810225187
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7755504070399221049}
+  m_CullTransparentMesh: 1
+--- !u!114 &3619349430151985246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7755504070399221049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Geist Heist/Assets/Prefabs/UI/Level Confirmation/FadeToBlackCanvas.prefab.meta
+++ b/Geist Heist/Assets/Prefabs/UI/Level Confirmation/FadeToBlackCanvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0149ec701953a784782033d31a875ed7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Geist Heist/Assets/Scenes/AlphaGreyboxScenes/InsideGlobeALPHA.unity
+++ b/Geist Heist/Assets/Scenes/AlphaGreyboxScenes/InsideGlobeALPHA.unity
@@ -1453,6 +1453,85 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4730828819555407057, guid: 4055aa459ed269f4d96922a92b03cece, type: 3}
   m_PrefabInstance: {fileID: 1747361080}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &369682468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 369682471}
+  - component: {fileID: 369682470}
+  - component: {fileID: 369682469}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &369682469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 369682468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.UI.InputSystemUIInputModule
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &369682470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 369682468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.EventSystems.EventSystem
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &369682471
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 369682468}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &375002373
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6541,6 +6620,7 @@ MonoBehaviour:
   confirmationText: Go to HUB?
   confirmationPopupPrefab: {fileID: 5103595946940546535, guid: 5bc7dd9fed6d12a4580e4eb6ceb61a03, type: 3}
   closeMenuOnConfirm: 0
+  hasConfirmationPopup: 0
 --- !u!4 &1776078475 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3ad7b59710a4a4647a7f1e01a2e07b96, type: 3}
@@ -8121,3 +8201,4 @@ SceneRoots:
   - {fileID: 157543108}
   - {fileID: 1855466633}
   - {fileID: 834645384}
+  - {fileID: 369682471}

--- a/Geist Heist/Assets/Scripts/GameManager.cs
+++ b/Geist Heist/Assets/Scripts/GameManager.cs
@@ -120,7 +120,7 @@ public class GameManager : Singleton<GameManager>
     {
         if (!InGodMode)
         {
-            SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            LevelManager.Instance.InstantiateFadeToBlack(() => SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex));
         }
     }
 
@@ -134,7 +134,8 @@ public class GameManager : Singleton<GameManager>
     /// <returns></returns>
     public Task InstantiateManagers()
     {
-        Instantiate(InputManagerPrefab).GetComponent<InputEvents>().Initialize();
+        if(InputEvents.Instance == null)
+            Instantiate(InputManagerPrefab).GetComponent<InputEvents>().Initialize();
         Instantiate(FMODEventsPrefab);
         Instantiate(LevelManagerPrefab); // initialization happens in PlayerManager
         Instantiate(SaveDataManagerPrefab);

--- a/Geist Heist/Assets/Scripts/LevelManager.cs
+++ b/Geist Heist/Assets/Scripts/LevelManager.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using UnityEngine.Events;
 
 public class LevelManager : DontDestroyOnLoadSingleton<LevelManager>
 {
@@ -19,6 +20,7 @@ public class LevelManager : DontDestroyOnLoadSingleton<LevelManager>
     private readonly HashSet<KeyType> savedKeys = new();
     private readonly HashSet<string> savedDoorIds = new();
     private readonly HashSet<string> activatedCheckpointIds = new();
+    [SerializeField] private GameObject fadeToBlack;
 
     /// <summary>
     /// Initializes the LevelManager every time a scene is loaded
@@ -122,6 +124,12 @@ public class LevelManager : DontDestroyOnLoadSingleton<LevelManager>
         {
             door.RestoreCheckpointStateIfNeeded();
         }
+    }
+
+    public void InstantiateFadeToBlack(UnityAction action)
+    {
+        FadeToBlack ftb = Instantiate(fadeToBlack).GetComponent<FadeToBlack>();
+        ftb.Initialize(action);
     }
 
     #region Scene Transition Scripts

--- a/Geist Heist/Assets/Scripts/Player/Interaction/SceneTransitionActionable.cs
+++ b/Geist Heist/Assets/Scripts/Player/Interaction/SceneTransitionActionable.cs
@@ -28,6 +28,8 @@ public class SceneTransitionActionable : MonoBehaviour, IActionable
     [Foldout("Advanced"), SerializeField] private bool closeMenuOnConfirm = false;
 
     private static bool anyLevelConfirmScreenOpen = false;
+    [Tooltip ("Setting this to false means the transition will ONLY do a fade to black.")]
+    [SerializeField] private bool hasConfirmationPopup = true;
 
     public void Action()
     {
@@ -36,6 +38,14 @@ public class SceneTransitionActionable : MonoBehaviour, IActionable
             Debug.Log("can't open new confirm screen, player is already in a confirmation menu");
             return;
         }
+
+        if (!hasConfirmationPopup)
+        {
+            Debug.Log("Going straight to fade");
+            LevelManager.Instance.InstantiateFadeToBlack(() => LevelManager.Instance.ChangeScene(sceneName));
+            return;
+        }
+
         anyLevelConfirmScreenOpen = true;
 
         // if i didnt have to spawn this in, that would be cool

--- a/Geist Heist/Assets/Scripts/Player/Movement/InputEvents.cs
+++ b/Geist Heist/Assets/Scripts/Player/Movement/InputEvents.cs
@@ -66,7 +66,7 @@ public class InputEvents : DontDestroyOnLoadSingleton<InputEvents>
         .WithY(0)
         .normalized;
 
-    public Vector2 InputDirection2D => Move.ReadValue<Vector2>();
+    public Vector2 InputDirection2D => (FadeToBlack.Instance == null) ? Move.ReadValue<Vector2>() : Vector2.zero;
     public static bool MovePressed, /*JumpPressed,*/ ActionPressed, InteractPressed, PausePressed/*, SpacePressed*/;
 
     #region Time Held

--- a/Geist Heist/Assets/Scripts/Player/Possession/TetherPossessable.cs
+++ b/Geist Heist/Assets/Scripts/Player/Possession/TetherPossessable.cs
@@ -55,7 +55,7 @@ public class TetherPossessable : IInputHandler
         SaveDataManager.Instance.MarkSceneAsCompleted(SceneManager.GetActiveScene().name);
 
         //SceneManager.LoadScene(HubScene);
-        LevelManager.Instance.ChangeScene(HubScene);
+        LevelManager.Instance.InstantiateFadeToBlack(() => LevelManager.Instance.ChangeScene(HubScene));
     }
 
     #region action

--- a/Geist Heist/Assets/Scripts/StaticUtilities.cs
+++ b/Geist Heist/Assets/Scripts/StaticUtilities.cs
@@ -698,6 +698,7 @@ public static class StaticUtilities
         if(_coroutineRunner == null)
         {
             var coroutineGameobject = new GameObject();
+            GameObject.DontDestroyOnLoad(coroutineGameobject);
             coroutineGameobject.name = "Static Utilities Coroutine Runner";
             _coroutineRunner = coroutineGameobject.AddComponent<StaticUtilitiesCoroutineRunner>();
         }

--- a/Geist Heist/Assets/Scripts/UI/Pause Menu/PauseMenu.cs
+++ b/Geist Heist/Assets/Scripts/UI/Pause Menu/PauseMenu.cs
@@ -160,13 +160,13 @@ public class PauseMenu : MonoBehaviour
     {
         ClosePauseMenu();
         Time.timeScale = 1;
-        SceneManager.LoadScene(HubScene);
+        LevelManager.Instance.InstantiateFadeToBlack(() => SceneManager.LoadScene(HubScene));
     }
 
     void OnConfirmQuitToMainMenuButtonClicked()
     {
         Time.timeScale = 1;
-        SceneManager.LoadScene(MainMenuScene);
+        LevelManager.Instance.InstantiateFadeToBlack(() => SceneManager.LoadScene(MainMenuScene));
     }
 
     #endregion
@@ -174,7 +174,7 @@ public class PauseMenu : MonoBehaviour
     #region Debug UI Buttons
     void RestartLevelButtonClicked()
     {
-        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+        LevelManager.Instance.InstantiateFadeToBlack(() => SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex));
     }
 
     void ResetSaveDataButtonClicked()

--- a/Geist Heist/Assets/Scripts/UI/Scene Transitions/FadeToBlack.cs
+++ b/Geist Heist/Assets/Scripts/UI/Scene Transitions/FadeToBlack.cs
@@ -1,0 +1,38 @@
+/*
+ * Contributors: Sky
+ * Creation Date: 2/26/26
+ * Last Modified: 2/26/26
+ * 
+ * Brief Description: Reference for a fade to black, calls the coroutine from the static utilities class
+ */
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class FadeToBlack : Singleton<FadeToBlack>
+{
+    private Coroutine fadeCoroutine;
+    [SerializeField] private CanvasGroup fadeCanvasGroup;
+    [SerializeField] private float secondsForFade = 1;
+    public void Initialize(UnityAction action)
+    {
+        DontDestroyOnLoad(gameObject);
+
+        if (fadeCoroutine == null)
+        {
+            fadeCanvasGroup.alpha = 0;
+            fadeCoroutine = StartCoroutine(FadeAnimation(action));
+        }
+    }
+
+    private IEnumerator FadeAnimation(UnityAction action)
+    {
+        yield return StaticUtilities.FadeToVisible(fadeCanvasGroup, secondsForFade);
+        action();
+        yield return StaticUtilities.FadeToHidden(fadeCanvasGroup, secondsForFade);
+        Destroy(gameObject);
+        fadeCoroutine = null;
+    }
+
+
+}

--- a/Geist Heist/Assets/Scripts/UI/Scene Transitions/FadeToBlack.cs.meta
+++ b/Geist Heist/Assets/Scripts/UI/Scene Transitions/FadeToBlack.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 574413415719e3244bab524e7c1cf53a


### PR DESCRIPTION
Added fade ins + outs to scene transitions, player death, pause menu buttons, and tether transitions
Added new bool on scene transition objects to skip the confirmation screen, will go straight to fading

Test: level transitions, getting caught by guards, possessing tethers, pause menu buttons